### PR TITLE
Init pkg->tags to NULL in pkg_init

### DIFF
--- a/libopkg/pkg.c
+++ b/libopkg/pkg.c
@@ -85,6 +85,7 @@ pkg_init(pkg_t *pkg)
      pkg->maintainer = NULL;
      pkg->section = NULL;
      pkg->description = NULL;
+     pkg->tags = NULL;
      pkg->state_want = SW_UNKNOWN;
      pkg->wanted_by = pkg_vec_alloc();
      pkg->state_flag = SF_OK;


### PR DESCRIPTION
# Bug
```c
pkg_t pkg;
pkg_init_from_file(&next, "/tmp/some.ipk"); // This calls pkg_init() under the hood
// Use pkg here
pkg_deinit(&pkg); // ==> free(pkg->tags) freeing an uninitialized pointer
```

This is not surfacing if one uses the `pkg_new()` call, as the underlaying `calloc()` sets this to 0, which could be NULL, so the free is ok. But as the described method is also legit by the API and spares a possible memory leak, the init should be added.